### PR TITLE
Notify Slack for new user requests

### DIFF
--- a/.github/workflows/new-user-notify-slack.yml
+++ b/.github/workflows/new-user-notify-slack.yml
@@ -1,0 +1,19 @@
+name: Notify Slack for New User requests
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  new-user-notify-slack:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, "new-user")
+    steps:
+      - uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: cal-itp-bot
+          SLACK_MSG_AUTHOR: cal-itp-bot
+          SLACK_ICON: https://github.com/cal-itp-bot.png?size=48
+          SLACK_MESSAGE: "A Hubspot new user request was submitted: ${{ github.event.issue.html_url }}"
+          MSG_MINIMAL: true

--- a/.github/workflows/new-user-notify-slack.yml
+++ b/.github/workflows/new-user-notify-slack.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.issue.labels.*.name, "new-user")
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - name: Slack notification
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: cal-itp-bot


### PR DESCRIPTION
Via the [`rtCamp/action-slack-notify`](https://github.com/rtCamp/action-slack-notify) action.

Using a channel-specific webhook and triggered by an issue being labeled with the `new-user` label.